### PR TITLE
Import PropTypes from 'prop-types'

### DIFF
--- a/src/LayoutProvider.js
+++ b/src/LayoutProvider.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
+import { PropTypes } from 'prop-types'
 import { Dimensions } from 'react-native'
 import shallowEqual from 'shallowequal'
 

--- a/src/defaultLayoutTypes.js
+++ b/src/defaultLayoutTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import { PropTypes } from 'prop-types'
 
 export default {
   label: PropTypes.string.isRequired,

--- a/src/getLayout.js
+++ b/src/getLayout.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react'
+import { PropTypes } from 'prop-types'
 import shallowEqual from 'shallowequal'
 import hoistStatics from 'hoist-non-react-statics'
 


### PR DESCRIPTION
Hi,

Thank you for making this package available!

I'm using it via react-native-layout-tester and it generates an error on importing PropTypes, which seems to have moved to 'prop-types' from 'react' at some point. This pull request includes the changes I made to get it working for me.